### PR TITLE
Migrate to idiomatic rust module pattern

### DIFF
--- a/registry-resolver/src/registry_client.rs
+++ b/registry-resolver/src/registry_client.rs
@@ -1,7 +1,7 @@
 use mockall::*;
 use registry::registry_service_client::RegistryServiceClient;
 
-#[path = "../gen/registry_api.v1.rs"]
+#[path = "gen/registry_api.v1.rs"]
 pub mod registry;
 
 pub struct GrpcClient {


### PR DESCRIPTION
Moved to newer module hierarchy pattern:
![image](https://user-images.githubusercontent.com/11223234/172419881-482ce2ab-cbfb-4fc0-9924-c0b8e2dde9f9.png)

>  Note: Prior to rustc 1.30, using mod.rs files was the way to load a module with nested children. It is encouraged to use the new naming convention as it is more consistent, and avoids having many files named mod.rs within a project.


[source](https://doc.rust-lang.org/reference/items/modules.html#module-source-filenames)