### PR TITLE
Create Identity method added with Vector functionality

### DIFF
--- a/ffi/headers/ssi_ffi.h
+++ b/ffi/headers/ssi_ffi.h
@@ -20,6 +20,9 @@ typedef struct RustError {
 
 } RustError_t;
 
+void free_rust_error (
+    RustError_t rust_error);
+
 typedef struct DidDocument DidDocument_t;
 
 
@@ -31,13 +34,35 @@ bool registry_create_did (
     char const * did,
     DidDocument_t * document);
 
-void free_rust_error (
-    RustError_t rust_error);
-
 DidDocument_t * create_identity (
     RustError_t * rust_error,
     char const * did_method,
     char const * mnemonic_input);
+
+
+#include <stddef.h>
+#include <stdint.h>
+
+/** \brief
+ *  Same as [`Vec<T>`][`rust::Vec`], but with guaranteed `#[repr(C)]` layout
+ */
+typedef struct Vec_uint8 {
+
+    uint8_t * ptr;
+
+    size_t len;
+
+    size_t cap;
+
+} Vec_uint8_t;
+
+Vec_uint8_t * create_identity_vec (
+    RustError_t * rust_error,
+    char const * did_method,
+    char const * mnemonic_input);
+
+void free_identity_did_doc (
+    DidDocument_t * did_doc);
 
 
 #ifdef __cplusplus

--- a/ffi/tests-c/main.c
+++ b/ffi/tests-c/main.c
@@ -26,6 +26,13 @@ DidDocument_t* test_create_did_doc(void) {
     return did_doc_rsp;
 }
 
+void test_create_did_doc_vecs(void) {
+    char did_method[] = "DID_METHOD";
+    char mnemonic[] = "";
+    Vec_uint8_t *did_doc_rsp = create_identity_vec(NULL, did_method, mnemonic);
+    TEST_ASSERT_NOT_NULL(did_doc_rsp);
+}
+
 void test_push_did_doc_integration(void) {
     DidDocument_t *did_document = test_create_did_doc();
     printf("\n test_create_did_doc did_document received \n");
@@ -37,6 +44,7 @@ void test_push_did_doc_integration(void) {
 
 int main(void) {
     UNITY_BEGIN();
+    RUN_TEST(test_create_did_doc_vecs);
     RUN_TEST(test_push_did_doc_integration);
     return UNITY_END();
 }


### PR DESCRIPTION
test_create_did_doc_vec added because Vec_uint8_t *did_doc_rsp type is needed on the receiver side