### PR TITLE
Use `OUT_DIR` for codegen

### DIFF
--- a/.github/workflows/release_ffi.yaml
+++ b/.github/workflows/release_ffi.yaml
@@ -73,10 +73,10 @@ jobs:
       - run: sudo chown -R "$USER:$USER" "/home/$USER"
       - name: Install deps
         run: ./container/deps.sh --force grpc_health_probe flatc cargo-make protoc buf
-      - run: sudo chown -R "$USER:$USER" "/home/$USER"        
+      - run: sudo chown -R "$USER:$USER" "/home/$USER"
       - run: cd ./registry_resolver && buf generate buf.build/knox-networks/registry-mgmt:f7ff6f57030c418e886459a18b35645e
       - run: chmod -R 0777 ./registry_resolver/src/gen
-      
+
       - run: cargo make ffi-build
 
       - run: cargo make ffi-header
@@ -123,15 +123,15 @@ jobs:
       - name: buf generate
         run: cd ./registry_resolver && buf generate buf.build/knox-networks/registry-mgmt:f7ff6f57030c418e886459a18b35645e
 
-      - name: Build Cross-Platform FFI 
-        run: cross build --features registry_resolver/ci_ffi_build --release --target ${{ matrix.arch }} --package ssi-ffi
+      - name: Build Cross-Platform FFI
+        run: cross build --release --target ${{ matrix.arch }} --package ssi-ffi
 
       - name: Prepare to Stage Release
         run: |
           chmod g+w "target/${{ matrix.arch }}/release/libssi_ffi.so"
           mkdir ./stage_release_ssi
           chmod g+w ./stage_release_ssi
-      
+
       - name: Stage Release
         env:
           IMAGE_TAG: ${{ needs.init.outputs.image_tag }}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -422,7 +422,7 @@ mod tests {
 
         match expanded {
             Err(e) => {
-                println!("Error: {:?}", e);
+                println!("Error: {e:?}");
             }
             Ok(expanded) => {
                 for object in expanded.into_value() {

--- a/core/src/proof.rs
+++ b/core/src/proof.rs
@@ -84,7 +84,7 @@ mod tests {
                     .decoded_relational_verify(&comparison, proof.proof_value, relation)
                     .is_ok());
             }
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!("{e:?}"),
         }
     }
 }

--- a/registry_resolver/buf.gen.yaml
+++ b/registry_resolver/buf.gen.yaml
@@ -1,12 +1,12 @@
 version: v1
 plugins:
   - plugin: buf.build/community/neoeinstein-prost
-    out: src/gen
+    out: .
     opt:
       - compile_well_known_types
       - extern_path=.google.protobuf=::pbjson_types
 
   - plugin: buf.build/community/neoeinstein-tonic
-    out: src/gen
+    out: .
     opt:
       - no_server

--- a/registry_resolver/build.rs
+++ b/registry_resolver/build.rs
@@ -1,21 +1,13 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(not(feature = "ci_ffi_build"))]
     {
-        let out_dir = format!(
-            "{}/{}",
-            std::env::var("OUT_DIR").unwrap(),
-            std::env::var("CARGO_PKG_NAME").unwrap(),
-        );
-
-        println!("cargo:warning={out_dir}");
-
         let package_path = "buf.build/knox-networks/registry-mgmt";
         let commit = "d65b89f5f58c4e2ca3d64401cf81b220";
         let std::process::Output { status, stderr, .. } = std::process::Command::new("buf")
             .arg("generate")
             .arg(format!("{package_path}:{commit}"))
             .arg("--output")
-            .arg(out_dir)
+            .arg(std::env::var("OUT_DIR").unwrap())
             .output()?;
         if !status.success() {
             return Err(String::from_utf8_lossy(&stderr).into());

--- a/registry_resolver/build.rs
+++ b/registry_resolver/build.rs
@@ -1,22 +1,14 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    #[cfg(not(feature = "ci_ffi_build"))]
-    {
-        let package_path = "buf.build/knox-networks/registry-mgmt";
-        let commit = "d65b89f5f58c4e2ca3d64401cf81b220";
-        let std::process::Output { status, stderr, .. } = std::process::Command::new("buf")
-            .arg("generate")
-            .arg(format!("{package_path}:{commit}"))
-            .arg("--output")
-            .arg(std::env::var("OUT_DIR").unwrap())
-            .output()?;
-        if !status.success() {
-            return Err(String::from_utf8_lossy(&stderr).into());
-        }
-        Ok(())
+    let package_path = "buf.build/knox-networks/registry-mgmt";
+    let commit = "d65b89f5f58c4e2ca3d64401cf81b220";
+    let std::process::Output { status, stderr, .. } = std::process::Command::new("buf")
+        .arg("generate")
+        .arg(format!("{package_path}:{commit}"))
+        .arg("--output")
+        .arg(std::env::var("OUT_DIR").unwrap())
+        .output()?;
+    if !status.success() {
+        return Err(String::from_utf8_lossy(&stderr).into());
     }
-
-    #[cfg(feature = "ci_ffi_build")]
-    {
-        Ok(())
-    }
+    Ok(())
 }

--- a/registry_resolver/build.rs
+++ b/registry_resolver/build.rs
@@ -1,11 +1,21 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(not(feature = "ci_ffi_build"))]
     {
+        let out_dir = format!(
+            "{}/{}",
+            std::env::var("OUT_DIR").unwrap(),
+            std::env::var("CARGO_PKG_NAME").unwrap(),
+        );
+
+        println!("cargo:warning={out_dir}");
+
         let package_path = "buf.build/knox-networks/registry-mgmt";
         let commit = "d65b89f5f58c4e2ca3d64401cf81b220";
         let std::process::Output { status, stderr, .. } = std::process::Command::new("buf")
             .arg("generate")
             .arg(format!("{package_path}:{commit}"))
+            .arg("--output")
+            .arg(out_dir)
             .output()?;
         if !status.success() {
             return Err(String::from_utf8_lossy(&stderr).into());

--- a/registry_resolver/src/registry_client.rs
+++ b/registry_resolver/src/registry_client.rs
@@ -1,7 +1,7 @@
 #[allow(non_snake_case, clippy::all, unused_imports, dead_code)]
 #[rustfmt::skip]
 pub mod registry {
-    include!(concat!(env!("OUT_DIR"), '/', env!("CARGO_PKG_NAME"), "/registry_api.v1.rs"));
+    include!(concat!(env!("OUT_DIR"), "/registry_api.v1.rs"));
 }
 
 #[derive(Clone, Debug)]

--- a/registry_resolver/src/registry_client.rs
+++ b/registry_resolver/src/registry_client.rs
@@ -1,7 +1,8 @@
 #[allow(non_snake_case, clippy::all, unused_imports, dead_code)]
 #[rustfmt::skip]
-#[path = "gen/registry_api.v1.rs"]
-pub mod registry;
+pub mod registry {
+    include!(concat!(env!("OUT_DIR"), '/', env!("CARGO_PKG_NAME"), "/registry_api.v1.rs"));
+}
 
 #[derive(Clone, Debug)]
 pub struct GrpcClient {

--- a/registry_resolver/src/registry_client.rs
+++ b/registry_resolver/src/registry_client.rs
@@ -1,5 +1,3 @@
-#[allow(non_snake_case, clippy::all, unused_imports, dead_code)]
-#[rustfmt::skip]
 pub mod registry {
     include!(concat!(env!("OUT_DIR"), "/registry_api.v1.rs"));
 }


### PR DESCRIPTION
To be inline with the comment below and to remove build artifacts from the repo, `OUT_DIR` is used as the build output directory of `registry_resolver`: 
https://github.com/ipetkov/crane/discussions/342#discussioncomment-6287577