### PR TITLE
Changes to facilitate building within nix

### DIFF
--- a/registry_resolver/build.rs
+++ b/registry_resolver/build.rs
@@ -3,8 +3,11 @@ use std::{env, path::PathBuf};
 
 fn main() -> Result<(), Report<BuildError>> {
     let out_dir = env::var("OUT_DIR").unwrap();
+    println!("cargo:warning={out_dir}");
 
     let proto_dir = PathBuf::from(&out_dir).join("protos");
+    let protofetch_cache_dir = PathBuf::from(&out_dir).join("protofetch_cache_dir");
+    std::fs::create_dir_all(&protofetch_cache_dir).report_as()?;
 
     let std::process::Output {
         status,
@@ -15,6 +18,8 @@ fn main() -> Result<(), Report<BuildError>> {
         .env("RUST_LOG", "TRACE")
         .arg("--output-proto-directory")
         .arg(&proto_dir)
+        .arg("--cache-directory")
+        .arg(&protofetch_cache_dir)
         .arg("fetch")
         .output()
         .report_as()?;

--- a/registry_resolver/build.rs
+++ b/registry_resolver/build.rs
@@ -21,7 +21,7 @@ fn main() -> Result<(), Report<BuildError>> {
     command.arg("fetch");
 
     if let Ok(dir) = env::var("PROTOFETCH_OVERRIDE_REPOSITORY") {
-        println!("Value of PROTOFETCH_OVERRIDE_REPOSITORY: {dir}");
+        println!("cargo:warning=PROTOFETCH_OVERRIDE_REPOSITORY=\"{dir}\"");
         command
             .arg("--source-overrides")
             .arg(&format!("registry-mgmt={}", dir));


### PR DESCRIPTION
This PR does two things, to facilitate `ssi` being built within a nix flake:
* use a local cache directory within $OUT_DIR for the protofetch cache, instead of a global cache
* expose a `PROTOFETCH_OVERRIDE_REPOSITORY` env var, which will instruct the internal protofetch process to fetch the protobuf from a local file instead of trying to directly fetch it from github