### PR TITLE
Clarify protobuf requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ Digital Identity Core
 ## Requirements
 At the moment we make no promise to support anything but the latest version of Rust. Current minimum version of rust (MVR): 1.64
 
+We use the [protofetch](https://github.com/coralogix/protofetch) tool for managing Protobuf files in the `build.rs` script 
+for `registry_resolver`. Make sure it is installed on your system - one way to do this is by running `cargo install protofetch`
+to build it from source.
+
 ## Installation
 You can utilize `ssi` by importing it via GitHub through the main branch. At the moment the crate is not published on crates.io
 ```

--- a/registry_resolver/build.rs
+++ b/registry_resolver/build.rs
@@ -1,5 +1,5 @@
 use bigerror::{BuildError, Report, ReportAs, Reportable};
-use std::{env, path::PathBuf};
+use std::{env, io, path::PathBuf};
 
 fn main() -> Result<(), Report<BuildError>> {
     let out_dir = env::var("OUT_DIR").unwrap();
@@ -32,7 +32,12 @@ fn main() -> Result<(), Report<BuildError>> {
         stderr,
         stdout,
         ..
-    } = command.output().report_as()?;
+    } = command.output().map_err(|err| {
+        if err.kind() == io::ErrorKind::NotFound {
+            println!("`protofetch` binary not found, make sure it is installed on your system and available in PATH");
+        }
+        err
+    }).report_as()?;
 
     println!(
         "protofetch stdout: {}",


### PR DESCRIPTION
Add some error-logging in the `build.rs` file for `registry-resolver` if executing the `protofetch` `Command` fails, to clarify that the user should make sure it is installed; also add a note in the README about it.