### PR TITLE
Clean up dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2135563fb5c609d2b2b87c1e8ce7bc41b0b45430fa9661f457981503dd5bf0"
+checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
 dependencies = [
  "memchr",
 ]
@@ -1894,9 +1894,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.13"
+version = "0.38.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+checksum = "747c788e9ce8e92b12cd485c49ddf90723550b654b32508f979b71a7b1ecda4f"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -2154,9 +2154,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
 
 [[package]]
 name = "socket2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2128,6 +2128,7 @@ version = "0.4.0"
 dependencies = [
  "ed25519-zebra",
  "multibase",
+ "rand 0.8.5",
  "serde",
  "sha2 0.10.7",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,101 +80,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
-dependencies = [
- "async-lock",
- "async-task",
- "concurrent-queue",
- "fastrand 1.9.0",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite",
- "log",
- "parking",
- "polling",
- "rustix 0.37.23",
- "slab",
- "socket2 0.4.9",
- "waker-fn",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,12 +102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-task"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
-
-[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,12 +111,6 @@ dependencies = [
  "quote",
  "syn 2.0.37",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
 name = "autocfg"
@@ -344,21 +237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-task",
- "atomic-waker",
- "fastrand 1.9.0",
- "futures-lite",
- "log",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -407,15 +285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62ec6771ecfa0762d24683ee5a32ad78487a3d3afdc0fb8cae19d2c5deb50b7c"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "contextual"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,15 +313,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -643,21 +503,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
 name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,21 +582,6 @@ name = "futures-io"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
-
-[[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
 
 [[package]]
 name = "futures-macro"
@@ -850,18 +680,6 @@ name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
-
-[[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "h2"
@@ -1057,15 +875,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "inventory"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,17 +894,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
 ]
 
 [[package]]
@@ -1134,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "json-ld"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df793ab9b4ef634ff46ef61e265dd95a253ceaa166efcc180c16a06bd36aeb9"
+checksum = "804a027f535a94f560af7182e1c5c1cbffba579e783392c5699743aab6442106"
 dependencies = [
  "contextual",
  "futures",
@@ -1148,13 +946,14 @@ dependencies = [
  "json-syntax",
  "locspan",
  "rdf-types",
+ "thiserror",
 ]
 
 [[package]]
 name = "json-ld-compaction"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce0e40c1dc9c2c1221d38fcb4a7f36bcc3723a2125a46094a0b9dd44289af928"
+checksum = "36937a7179489ee0ca59d85a5ed1efe03ef868b02929fa51c08cf2d9a6e63df0"
 dependencies = [
  "contextual",
  "derivative",
@@ -1169,13 +968,14 @@ dependencies = [
  "locspan",
  "mown",
  "rdf-types",
+ "thiserror",
 ]
 
 [[package]]
 name = "json-ld-context-processing"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66631abc4dd27e910105815b763df7ac37ac3b5892a584f37493920d1006f8be"
+checksum = "bbb70837608ba8283480ceb11b1ad3efa034b497c8a89c1ab09213a2629f0b1c"
 dependencies = [
  "contextual",
  "futures",
@@ -1185,13 +985,14 @@ dependencies = [
  "locspan",
  "mown",
  "rdf-types",
+ "thiserror",
 ]
 
 [[package]]
 name = "json-ld-core"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e059326eebd8808b284f6cb9ba5f666e7186bde1e65dd1145fa4aeda20de9fd9"
+checksum = "646445c329f5bd9fd0f2c04575fb91e708e4a78275ed92e832383495c3beb4a9"
 dependencies = [
  "contextual",
  "derivative",
@@ -1213,13 +1014,14 @@ dependencies = [
  "ryu-js",
  "smallvec",
  "static-iref",
+ "thiserror",
 ]
 
 [[package]]
 name = "json-ld-expansion"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5ffd06b840b067cc5aae5cdee6c9deb5bef6635001c936741b85444f34513cb"
+checksum = "670588e31f803452f48df6b2e028859884ff00ff16cf3690109f5ca7a9746044"
 dependencies = [
  "contextual",
  "derivative",
@@ -1233,13 +1035,14 @@ dependencies = [
  "locspan",
  "mown",
  "rdf-types",
+ "thiserror",
 ]
 
 [[package]]
 name = "json-ld-syntax"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c609a30363e53e5c316128177799d3aff40a43547022eddc99dba078ab781b"
+checksum = "8b133204002b55ee696ee8c531e5b125fc78e2fb34b6b3c4d8ffbe0cd51d9e6d"
 dependencies = [
  "contextual",
  "decoded-char",
@@ -1253,6 +1056,7 @@ dependencies = [
  "locspan-derive",
  "rdf-types",
  "smallvec",
+ "thiserror",
 ]
 
 [[package]]
@@ -1282,15 +1086,6 @@ dependencies = [
  "ryu-js",
  "smallstr",
  "smallvec",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -1386,12 +1181,6 @@ checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
@@ -1423,15 +1212,6 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-dependencies = [
- "value-bag",
-]
-
-[[package]]
-name = "map"
-version = "0.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddce5132fa5c614c7de5b17df939b227e6ae3fc763b4498da5c13d87b7e1248c"
 
 [[package]]
 name = "matchers"
@@ -1614,12 +1394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "parking"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14f2252c834a40ed9bb5422029649578e63aa341ac401f74e719dd1afda8394e"
-
-[[package]]
 name = "pbjson"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,22 +1501,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "polling"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
-dependencies = [
- "autocfg",
- "bitflags 1.3.2",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -1974,15 +1732,17 @@ dependencies = [
 
 [[package]]
 name = "rdf-types"
-version = "0.12.19"
+version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d95f82a1f30f2d62e77b775ef4863f67ffafef1fc2c95ebfb55f3750be55df"
+checksum = "d937485610ef88fde97044e8613bdbe8f585f75ab7a665f0d37b9a283621a0c8"
 dependencies = [
  "contextual",
+ "indexmap 1.9.3",
  "iref",
  "langtag",
  "locspan",
  "locspan-derive",
+ "thiserror",
 ]
 
 [[package]]
@@ -2134,20 +1894,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.8",
- "windows-sys",
-]
-
-[[package]]
-name = "rustix"
 version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
@@ -2155,7 +1901,7 @@ dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.7",
+ "linux-raw-sys",
  "windows-sys",
 ]
 
@@ -2382,7 +2128,6 @@ version = "0.4.0"
 dependencies = [
  "ed25519-zebra",
  "multibase",
- "rand 0.8.5",
  "serde",
  "sha2 0.10.7",
  "thiserror",
@@ -2453,7 +2198,6 @@ dependencies = [
 name = "ssi-ffi"
 version = "0.4.0"
 dependencies = [
- "ephemeral_resolver",
  "registry_resolver",
  "safer-ffi",
  "serde",
@@ -2472,13 +2216,11 @@ name = "ssi_core"
 version = "0.4.0"
 dependencies = [
  "assert-json-diff",
- "async-std",
  "async-trait",
  "chrono",
  "iref",
  "json-ld",
  "locspan",
- "map",
  "mockall",
  "rstest",
  "serde",
@@ -2546,9 +2288,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.0",
+ "fastrand",
  "redox_syscall",
- "rustix 0.38.13",
+ "rustix",
  "windows-sys",
 ]
 
@@ -2923,22 +2665,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
-name = "value-bag"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "want"
@@ -2984,18 +2714,6 @@ dependencies = [
  "quote",
  "syn 2.0.37",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3055,7 +2773,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.13",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,9 +1224,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1202b2a6f884ae56f04cff409ab315c5ce26b5e58d7412e484f01fd52f52ef"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
@@ -1913,7 +1913,7 @@ checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki 0.101.5",
+ "rustls-webpki 0.101.6",
  "sct",
 ]
 
@@ -1950,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.5"
+version = "0.101.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
 dependencies = [
  "ring",
  "untrusted",
@@ -2438,9 +2438,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
+checksum = "1d68074620f57a0b21594d9735eb2e98ab38b17f80d3fcb189fca266771ca60d"
 dependencies = [
  "bytes",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,23 +15,23 @@ members = [
 
 
 [workspace.dependencies]
-base64 = "0.13.0"
-chrono = { version = "0.4.19", features = ["serde"] }
-futures = { version = "0.3.21", default-features = false }
-mockall = { version = "0.11.2" }
-multibase = "0.9.0"
-prost = "0.11.0"
-prost-types = "0.11.0"
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.85"
+base64 = "0.13.1"
+chrono = { version = "0.4.31", features = ["serde"] }
+futures = { version = "0.3.28", default-features = false }
+mockall = { version = "0.11.4" }
+multibase = "0.9.1"
+prost = "0.11.9"
+prost-types = "0.11.9"
+serde = { version = "1.0.188", features = ["derive"] }
+serde_json = "1.0.107"
 signature = "1.6.4"
-thiserror = "1.0.37"
+thiserror = "1.0.48"
 tiny-bip39 = "0.8.2"
-tokio = { version = "1.21.0", features = ["macros", "rt-multi-thread"] }
-tokio-stream = "0.1.8"
+tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }
+tokio-stream = "0.1.14"
 tonic = { version = "0.9.2", features = ["tls", "tls-roots", "tls-webpki-roots"] }
-tracing = "0.1.34"
+tracing = "0.1.37"
 tracing-error = "0.2.0"
-tracing-test = "0.2.2"
-uuid = { version = "1.2.1", features = ["v4", "serde"] }
+tracing-test = "0.2.4"
+uuid = { version = "1.4.1", features = ["v4", "serde"] }
 bigerror = { git = "https://github.com/knox-networks/bigerror", rev = "5a42952"}

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -6,10 +6,10 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.53"
+async-trait = "0.1.73"
 chrono = {workspace = true}
 serde_json = {workspace = true}
-sha2 = "0.10.2"
+sha2 = "0.10.7"
 signature = { path = "../signature" }
 serde = { workspace = true}
 mockall = {workspace = true}
@@ -19,10 +19,10 @@ json-ld = "0.15.0"
 [dev-dependencies]
 rstest = "0.15.0"
 assert-json-diff = "2.0.2"
-tokio-test = "0.4.2"
-iref = "2.2.2"
+tokio-test = "0.4.3"
+iref = "2.2.3"
 static-iref = "2.0.0"
-locspan = "0.7.13"
+locspan = "0.7.16"
 
 [features]
 static = []

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -14,14 +14,12 @@ signature = { path = "../signature" }
 serde = { workspace = true}
 mockall = {workspace = true}
 thiserror = {workspace = true}
-json-ld = "0.11.0"
+json-ld = "0.15.0"
 
 [dev-dependencies]
 rstest = "0.15.0"
-map = "0.0.0"
 assert-json-diff = "2.0.2"
 tokio-test = "0.4.2"
-async-std = "1.12.0"
 iref = "2.2.2"
 static-iref = "2.0.0"
 locspan = "0.7.13"

--- a/ephemeral_resolver/Cargo.toml
+++ b/ephemeral_resolver/Cargo.toml
@@ -7,14 +7,14 @@ edition.workspace = true
 
 [dependencies]
 ssi_core = { path = "../core" }
-async-trait = "0.1.53"
+async-trait = "0.1.73"
 serde_json = {workspace = true}
 tokio = { workspace = true }
 chrono.workspace = true
 
 
 [dev-dependencies]
-tokio-test = "0.4.2"
+tokio-test = "0.4.3"
 
 [features]
 static = []

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -8,7 +8,7 @@ name = "ssi_ffi"
 crate-type = ["cdylib", "staticlib"]
 
 [dependencies]
-serde_json = "1.0.81"
+serde_json = "1.0.107"
 safer-ffi = { version = "0.0.7", features = ["proc_macros", "log", "out-refs"] }
 registry_resolver = {path = "../registry_resolver" }
 ssi_core = { path = "../core" }
@@ -17,7 +17,7 @@ signature = { path = "../signature" }
 tokio = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 tracing = { workspace = true }
-tracing-subscriber = { version = "0.3.11", features = ["env-filter", "fmt", "json"] }
+tracing-subscriber = { version = "0.3.17", features = ["env-filter", "fmt", "json"] }
 tracing-error.workspace = true
 thiserror = { workspace = true }
 

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -13,7 +13,6 @@ safer-ffi = { version = "0.0.7", features = ["proc_macros", "log", "out-refs"] }
 registry_resolver = {path = "../registry_resolver" }
 ssi_core = { path = "../core" }
 signature = { path = "../signature" }
-ephemeral_resolver = { path = "../ephemeral_resolver" }
 
 tokio = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
@@ -24,4 +23,4 @@ thiserror = { workspace = true }
 
 [features]
 c-headers = ["safer-ffi/headers"]
-static = ["registry_resolver/static", "signature/static", "ssi_core/static", "ephemeral_resolver/static"]
+static = ["registry_resolver/static", "signature/static", "ssi_core/static"]

--- a/registry_resolver/Cargo.toml
+++ b/registry_resolver/Cargo.toml
@@ -7,12 +7,12 @@ edition.workspace = true
 
 [dependencies]
 tonic = { workspace = true }
-prost = "0.11.0"
-prost-types = "0.11.0"
+prost = "0.11.9"
+prost-types = "0.11.9"
 ssi_core = { path = "../core" }
 serde_json = {workspace = true}
-pbjson-types = "0.5.0"
-async-trait = "0.1.53"
+pbjson-types = "0.5.1"
+async-trait = "0.1.73"
 mockall = {workspace = true}
 serde = {workspace = true }
 tokio = { workspace = true }
@@ -21,7 +21,7 @@ chrono.workspace = true
 
 [dev-dependencies]
 rstest = "0.15.0"
-tokio-test = "0.4.2"
+tokio-test = "0.4.3"
 
 [build-dependencies]
 tonic-build = "0.8.4"

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -6,12 +6,13 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ed25519-zebra = "3.1.0"
+ed25519-zebra = "3.0.0"
 multibase = "0.9.1"
+rand = "0.8.5"
 tiny-bip39 = "0.8.2"
 thiserror = {workspace = true}
 serde = { workspace = true }
-sha2 = "0.10.7"
+sha2 = "0.10.2"
 
 [features]
 static = []

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -6,12 +6,12 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ed25519-zebra = "3.0.0"
+ed25519-zebra = "3.1.0"
 multibase = "0.9.1"
 tiny-bip39 = "0.8.2"
 thiserror = {workspace = true}
 serde = { workspace = true }
-sha2 = "0.10.2"
+sha2 = "0.10.7"
 
 [features]
 static = []

--- a/signature/Cargo.toml
+++ b/signature/Cargo.toml
@@ -8,7 +8,6 @@ edition.workspace = true
 [dependencies]
 ed25519-zebra = "3.0.0"
 multibase = "0.9.1"
-rand = "0.8.5"
 tiny-bip39 = "0.8.2"
 thiserror = {workspace = true}
 serde = { workspace = true }


### PR DESCRIPTION
Handle dependabot warnings: https://github.com/knox-networks/ssi/security/dependabot/7

* Removed unused dependencies with `cargo-udeps`:
  ```
  $ cargo +nightly udeps --all-targets

  unused dependencies:
  `ssi-ffi v0.4.0 (/Users/mkatychev/Documents/knox/ssi/ffi)`
  └─── dependencies
       └─── "ephemeral_resolver"
  `ssi_core v0.4.0 (/Users/mkatychev/Documents/knox/ssi/core)`
  └─── dev-dependencies
       ├─── "async-std"
       └─── "map"
  Note: They might be false-positive.
        For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
        To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.

  ```
  
* Run [`cargo upgrade`](https://github.com/killercup/cargo-edit#cargo-upgrade)
