### PR TITLE
29 Add Support RDFC-1.0 Normalization In Data Integrity Proofs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ephemeral_resolver"
 version = "0.4.0"
 dependencies = [
@@ -504,15 +513,6 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
@@ -537,6 +537,30 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "fragile"
@@ -591,21 +615,6 @@ name = "futures-io"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
-
-[[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
 
 [[package]]
 name = "futures-macro"
@@ -856,6 +865,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +901,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "idna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -896,15 +928,6 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -928,6 +951,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "iref"
@@ -1027,6 +1056,7 @@ version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "646445c329f5bd9fd0f2c04575fb91e708e4a78275ed92e832383495c3beb4a9"
 dependencies = [
+ "bytes",
  "contextual",
  "derivative",
  "futures",
@@ -1044,6 +1074,7 @@ dependencies = [
  "permutohedron",
  "pretty_dtoa",
  "rdf-types",
+ "reqwest",
  "ryu-js",
  "smallvec",
  "static-iref",
@@ -1208,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1299,9 +1330,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
@@ -1365,6 +1396,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
+name = "native-tls"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1421,10 +1470,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
+name = "openssl"
+version = "0.10.59"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a257ad03cd8fb16ad4172fedf8094451e1af1c4b70097636ef2eac9a5f0cc33"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a4130519a360279579c2053038317e40eff64d13fd3f004f9e1b72b8a6aaf9"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "overload"
@@ -1443,12 +1530,6 @@ name = "oxiri"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb175ec8981211357b7b379869c2f8d555881c55ea62311428ec0de46d89bd5c"
-
-[[package]]
-name = "parking"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "pbjson"
@@ -1558,6 +1639,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "ppv-lite86"
@@ -1889,6 +1976,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046cd98826c46c2ac8ddecae268eb5c2e58628688a5fc7a2643704a73faba95b"
+dependencies = [
+ "base64 0.21.4",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "resiter"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2170,6 +2295,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2251,9 +2388,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "7b5fac59a5cb5dd637972e5fca70daf0523c9067fcdc4842f053dae04a18f8e9"
 dependencies = [
  "libc",
  "windows-sys",
@@ -2262,7 +2399,7 @@ dependencies = [
 [[package]]
 name = "sophia"
 version = "0.8.0-alpha.2"
-source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=572512bd4a13dce4ca52f9310ac907b06dbea556#572512bd4a13dce4ca52f9310ac907b06dbea556"
 dependencies = [
  "sophia_api",
  "sophia_c14n",
@@ -2279,7 +2416,7 @@ dependencies = [
 [[package]]
 name = "sophia_api"
 version = "0.8.0-alpha.2"
-source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=572512bd4a13dce4ca52f9310ac907b06dbea556#572512bd4a13dce4ca52f9310ac907b06dbea556"
 dependencies = [
  "lazy_static",
  "mownstr",
@@ -2293,7 +2430,7 @@ dependencies = [
 [[package]]
 name = "sophia_c14n"
 version = "0.8.0-alpha.2"
-source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=572512bd4a13dce4ca52f9310ac907b06dbea556#572512bd4a13dce4ca52f9310ac907b06dbea556"
 dependencies = [
  "sha2 0.10.7",
  "sophia_api",
@@ -2304,7 +2441,7 @@ dependencies = [
 [[package]]
 name = "sophia_inmem"
 version = "0.8.0-alpha.2"
-source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=572512bd4a13dce4ca52f9310ac907b06dbea556#572512bd4a13dce4ca52f9310ac907b06dbea556"
 dependencies = [
  "sophia_api",
  "thiserror",
@@ -2313,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "sophia_iri"
 version = "0.8.0-alpha.2"
-source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=572512bd4a13dce4ca52f9310ac907b06dbea556#572512bd4a13dce4ca52f9310ac907b06dbea556"
 dependencies = [
  "lazy_static",
  "oxiri",
@@ -2325,7 +2462,7 @@ dependencies = [
 [[package]]
 name = "sophia_isomorphism"
 version = "0.8.0-alpha.2"
-source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=572512bd4a13dce4ca52f9310ac907b06dbea556#572512bd4a13dce4ca52f9310ac907b06dbea556"
 dependencies = [
  "sophia_api",
  "sophia_iri",
@@ -2334,9 +2471,9 @@ dependencies = [
 [[package]]
 name = "sophia_jsonld"
 version = "0.8.0-alpha.2"
-source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=572512bd4a13dce4ca52f9310ac907b06dbea556#572512bd4a13dce4ca52f9310ac907b06dbea556"
 dependencies = [
- "futures-lite",
+ "futures-util",
  "iref",
  "json-ld",
  "json-syntax",
@@ -2347,12 +2484,13 @@ dependencies = [
  "sophia_iri",
  "sophia_term",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]
 name = "sophia_resource"
 version = "0.8.0-alpha.2"
-source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=572512bd4a13dce4ca52f9310ac907b06dbea556#572512bd4a13dce4ca52f9310ac907b06dbea556"
 dependencies = [
  "sophia_api",
  "sophia_iri",
@@ -2363,7 +2501,7 @@ dependencies = [
 [[package]]
 name = "sophia_rio"
 version = "0.8.0-alpha.2"
-source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=572512bd4a13dce4ca52f9310ac907b06dbea556#572512bd4a13dce4ca52f9310ac907b06dbea556"
 dependencies = [
  "rio_api",
  "sophia_api",
@@ -2373,7 +2511,7 @@ dependencies = [
 [[package]]
 name = "sophia_term"
 version = "0.8.0-alpha.2"
-source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=572512bd4a13dce4ca52f9310ac907b06dbea556#572512bd4a13dce4ca52f9310ac907b06dbea556"
 dependencies = [
  "lazy_static",
  "sophia_api",
@@ -2382,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "sophia_turtle"
 version = "0.8.0-alpha.2"
-source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=572512bd4a13dce4ca52f9310ac907b06dbea556#572512bd4a13dce4ca52f9310ac907b06dbea556"
 dependencies = [
  "lazy_static",
  "oxiri",
@@ -2499,13 +2637,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "fastrand 2.0.0",
+ "fastrand",
  "redox_syscall",
  "rustix",
  "windows-sys",
@@ -2583,9 +2742,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.32.0"
+version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ed6077ed6cd6c74735e21f37eb16dc3935f96878b1fe961074089cc80893f9"
+checksum = "d0c014766411e834f7af5b8f4cf46257aab4036ca95e9d2c144a10f59ad6f5b9"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2593,7 +2752,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.4",
+ "socket2 0.5.5",
  "tokio-macros",
  "windows-sys",
 ]
@@ -2610,13 +2769,23 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -2843,6 +3012,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2870,6 +3045,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
+name = "url"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf8-decode"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2882,16 +3068,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "waker-fn"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "want"
@@ -2937,6 +3123,18 @@ dependencies = [
  "quote",
  "syn 2.0.37",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -3095,6 +3293,16 @@ name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,6 +2193,7 @@ dependencies = [
  "registry_resolver",
  "signature",
  "ssi_core",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,6 +504,15 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "fastrand"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6999dc1837253364c2ebb0704ba97994bd874e8f195d665c50b7548f6ea92764"
@@ -582,6 +591,21 @@ name = "futures-io"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-lite"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
+dependencies = [
+ "fastrand 1.9.0",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+ "waker-fn",
+]
 
 [[package]]
 name = "futures-macro"
@@ -872,6 +896,15 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1309,6 +1342,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7627d8bbeb17edbf1c3f74b21488e4af680040da89713b4217d0010e9cbd97e"
 
 [[package]]
+name = "mownstr"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bc45ce96192b5d8b20cffb10ccd85cc431c283a7d171a0d843ac0bd7d444598"
+
+[[package]]
 name = "multibase"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1431,24 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "oxilangtag"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d91edf4fbb970279443471345a4e8c491bf05bb283b3e6c88e4e606fd8c181b"
+
+[[package]]
+name = "oxiri"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb175ec8981211357b7b379869c2f8d555881c55ea62311428ec0de46d89bd5c"
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "pbjson"
@@ -1832,6 +1889,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resiter"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc95d56eb1865f69288945759cc0879d60ee68168dce676730275804ad2b276"
+
+[[package]]
 name = "ring"
 version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,6 +1907,23 @@ dependencies = [
  "untrusted",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "rio_api"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1924fa1f0e6d851f9b73b3c569e607c368a0d92995d99d563ad7bf1414696603"
+
+[[package]]
+name = "rio_turtle"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cec59971eafd99b9c7e3544bfcabafea81a7072ac51c9f46985ca0bd7ba6016"
+dependencies = [
+ "oxilangtag",
+ "oxiri",
+ "rio_api",
 ]
 
 [[package]]
@@ -2180,6 +2260,140 @@ dependencies = [
 ]
 
 [[package]]
+name = "sophia"
+version = "0.8.0-alpha.2"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+dependencies = [
+ "sophia_api",
+ "sophia_c14n",
+ "sophia_inmem",
+ "sophia_iri",
+ "sophia_isomorphism",
+ "sophia_jsonld",
+ "sophia_resource",
+ "sophia_rio",
+ "sophia_term",
+ "sophia_turtle",
+]
+
+[[package]]
+name = "sophia_api"
+version = "0.8.0-alpha.2"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+dependencies = [
+ "lazy_static",
+ "mownstr",
+ "regex",
+ "resiter",
+ "serde",
+ "sophia_iri",
+ "thiserror",
+]
+
+[[package]]
+name = "sophia_c14n"
+version = "0.8.0-alpha.2"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+dependencies = [
+ "sha2 0.10.7",
+ "sophia_api",
+ "sophia_iri",
+ "thiserror",
+]
+
+[[package]]
+name = "sophia_inmem"
+version = "0.8.0-alpha.2"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+dependencies = [
+ "sophia_api",
+ "thiserror",
+]
+
+[[package]]
+name = "sophia_iri"
+version = "0.8.0-alpha.2"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+dependencies = [
+ "lazy_static",
+ "oxiri",
+ "regex",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
+name = "sophia_isomorphism"
+version = "0.8.0-alpha.2"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+dependencies = [
+ "sophia_api",
+ "sophia_iri",
+]
+
+[[package]]
+name = "sophia_jsonld"
+version = "0.8.0-alpha.2"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+dependencies = [
+ "futures-lite",
+ "iref",
+ "json-ld",
+ "json-syntax",
+ "langtag",
+ "locspan",
+ "rdf-types",
+ "sophia_api",
+ "sophia_iri",
+ "sophia_term",
+ "thiserror",
+]
+
+[[package]]
+name = "sophia_resource"
+version = "0.8.0-alpha.2"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+dependencies = [
+ "sophia_api",
+ "sophia_iri",
+ "sophia_turtle",
+ "thiserror",
+]
+
+[[package]]
+name = "sophia_rio"
+version = "0.8.0-alpha.2"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+dependencies = [
+ "rio_api",
+ "sophia_api",
+ "sophia_iri",
+]
+
+[[package]]
+name = "sophia_term"
+version = "0.8.0-alpha.2"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+dependencies = [
+ "lazy_static",
+ "sophia_api",
+]
+
+[[package]]
+name = "sophia_turtle"
+version = "0.8.0-alpha.2"
+source = "git+https://github.com/pchampin/sophia_rs.git?rev=d6d73d78#d6d73d78abde7ef7961bfacc1d0031fd52e2e12f"
+dependencies = [
+ "lazy_static",
+ "oxiri",
+ "regex",
+ "rio_turtle",
+ "sophia_api",
+ "sophia_iri",
+ "sophia_rio",
+]
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,6 +2443,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.7",
  "signature",
+ "sophia",
  "static-iref",
  "thiserror",
  "tokio-test",
@@ -2290,7 +2505,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
  "cfg-if",
- "fastrand",
+ "fastrand 2.0.0",
  "redox_syscall",
  "rustix",
  "windows-sys",
@@ -2671,6 +2886,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "waker-fn"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0.107"
 signature = "1.6.4"
 thiserror = "1.0.48"
 tiny-bip39 = "0.8.2"
-tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.14"
 tonic = { version = "0.9.2", features = ["tls", "tls-roots", "tls-webpki-roots"] }
 tracing = "0.1.37"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,6 +15,7 @@ serde = { workspace = true}
 mockall = {workspace = true}
 thiserror = {workspace = true}
 json-ld = "0.15.0"
+sophia = { git = "https://github.com/pchampin/sophia_rs.git", rev = "d6d73d78", features = ["jsonld"] }
 
 [dev-dependencies]
 rstest = "0.15.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -15,7 +15,7 @@ serde = { workspace = true}
 mockall = {workspace = true}
 thiserror = {workspace = true}
 json-ld = "0.15.0"
-sophia = { git = "https://github.com/pchampin/sophia_rs.git", rev = "d6d73d78", features = ["jsonld"] }
+sophia = { git = "https://github.com/pchampin/sophia_rs.git", rev = "572512bd4a13dce4ca52f9310ac907b06dbea556", features = ["jsonld","http_client"] }
 
 [dev-dependencies]
 rstest = "0.15.0"

--- a/core/src/proof.rs
+++ b/core/src/proof.rs
@@ -1,5 +1,3 @@
-use sha2::{Digest, Sha512};
-
 mod normalization;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq)]
@@ -16,6 +14,16 @@ pub struct DataIntegrityProof {
     pub proof_value: String,
 }
 
+impl std::fmt::Display for DataIntegrityProof {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "{{\"type\": \"{}\", \"created\": \"{}\", \"verificationMethod\": \"{}\", \"proofPurpose\": \"{}\", \"proofValue\": \"{}\"}}",
+            self.proof_type, self.created, self.verification_method, self.proof_purpose, self.proof_value
+        )
+    }
+}
+
 // Use it as an example
 /// Given a JSON-LD document, create a data integrity proof for the document.
 /// Currently, only `Ed25519Signature2018` data integrity proofs in the JSON-LD format can be created.
@@ -24,11 +32,12 @@ pub fn create_data_integrity_proof<S: signature::suite::Signature>(
     doc: serde_json::Value,
     relation: signature::suite::VerificationRelation,
 ) -> Result<DataIntegrityProof, super::error::Error> {
-    let mut hasher = Sha512::new();
-    hasher.update(normalization::normalize(doc));
-    let result = hasher.finalize();
+    let hashed_normalized_doc = normalization::normalize(doc);
 
-    let encoded_sig = signer.encoded_relational_sign(&result, relation)?;
+    println!("result {:?}", hashed_normalized_doc);
+
+    let encoded_sig = signer.encoded_relational_sign(&hashed_normalized_doc, relation)?;
+
     Ok(DataIntegrityProof {
         proof_type: signer.get_proof_type(),
         created: chrono::Utc::now().to_rfc3339(),
@@ -40,7 +49,6 @@ pub fn create_data_integrity_proof<S: signature::suite::Signature>(
 
 #[cfg(test)]
 mod tests {
-    use sha2::Digest;
 
     use super::create_data_integrity_proof;
     use signature::suite::DIDSigner;
@@ -50,16 +58,23 @@ mod tests {
 
     #[rstest::rstest]
     #[case::success(
-        serde_json::Value::default(),
+        create_unverified_credential_doc(),
         signature::suite::VerificationRelation::AssertionMethod
     )]
     fn test_create_data_integrity_proof(
         #[case] doc: serde_json::Value,
         #[case] relation: signature::suite::VerificationRelation,
     ) {
-        let kp =
-            signature::suite::ed25519_2020::Ed25519KeyPair::new(TEST_DID_METHOD.to_string(), None)
-                .unwrap();
+        let phrase = "vague sell team fee cluster poet slush topic beef dish wise enter meat brave question before exhibit purity drill reward awkward plug ice dilemma";
+        let mnemonic = signature::suite::ed25519_2020::Mnemonic {
+            phrase: phrase.to_string(),
+            language: signature::suite::ed25519_2020::MnemonicLanguage::English,
+        };
+        let kp = signature::suite::ed25519_2020::Ed25519KeyPair::new(
+            TEST_DID_METHOD.to_string(),
+            Some(mnemonic),
+        )
+        .unwrap();
         let signer: signature::suite::ed25519_2020::Ed25519DidSigner = kp.clone().into();
         let verifier: signature::suite::ed25519_2020::Ed25519DidVerifier = kp.into();
         let res = create_data_integrity_proof(&signer, doc.clone(), relation);
@@ -67,18 +82,19 @@ mod tests {
         assert!(res.is_ok());
         match res {
             Ok(proof) => {
+                println!("{proof}");
                 assert_eq!(proof.proof_type, signer.get_proof_type());
                 assert_eq!(
                     proof.verification_method,
                     signer.get_verification_method(relation)
                 );
                 assert_eq!(proof.proof_purpose, relation.to_string());
-
-                let mut hasher = sha2::Sha512::new();
-                let encoded = doc.to_string();
-                let result = encoded.into_bytes();
-                hasher.update(result);
-                let comparison = hasher.finalize();
+                let comparison = crate::proof::normalization::normalize(doc);
+                // let mut hasher = sha2::Sha512::new();
+                // let encoded = doc.to_string();
+                // let result = encoded.into_bytes();
+                // hasher.update(result);
+                // let comparison = hasher.finalize();
 
                 assert!(verifier
                     .decoded_relational_verify(&comparison, proof.proof_value, relation)
@@ -86,5 +102,39 @@ mod tests {
             }
             Err(e) => panic!("{e:?}"),
         }
+    }
+    fn create_unverified_credential_doc() -> serde_json::Value {
+        let expect = serde_json::json!({
+                "@context": [
+                  "https://www.w3.org/ns/credentials/v2",
+                  "https://www.w3.org/2018/credentials/examples/v1"
+                ],
+                "credentialSubject": {
+                  "birthCountry": "Bahamas",
+                  "birthDate": "1981-04-01",
+                  "commuterClassification": "C1",
+                  "familyName": "Kim",
+                  "gender": "Male",
+                  "givenName": "Francis",
+                  "id": "did:knox:z6MkoBjc4GfEWrdAXAchrDrjc7LBuTVNXySswadG3apCKy9P",
+                  "image": "data:image/png;base64,iVBORw0KGgo...kJggg==",
+                  "lprCategory": "C09",
+                  "lprNumber": "000-000-204",
+                  "residentSince": "2015-01-01",
+                  "type": [
+                    "PermanentResident",
+                    "Person"
+                  ]
+                },
+                "id": "http://credential_mock:8000/api/credential/z6MkoBjc4GfEWrdAXAchrDrjc7LBuTVNXySswadG3apCKy9P",
+                "issuanceDate": "2022-10-28T19:35:20Z",
+                "issuer": "did:knox:z6Mkv9L4S8FQ3qcu8UqG8NFHt5LKcfzPeLvPJB7uW5vrp3WF",
+                "type": [
+                  "VerifiableCredential",
+                  "PermanentResidentCard"
+                ]
+        });
+
+        expect
     }
 }

--- a/core/src/proof/normalization.rs
+++ b/core/src/proof/normalization.rs
@@ -1,13 +1,12 @@
 use sophia::{
     api::{parser::QuadParser, source::QuadSource},
-    c14n::hash::HashFunction,
     inmem::dataset::FastDataset,
     jsonld::loader::HttpLoader,
 };
 
 pub fn create_hashed_normalized_doc(
     doc: serde_json::Value,
-) -> Result<[u8; 32], crate::error::Error> {
+) -> Result<Vec<u8>, crate::error::Error> {
     let encoded = doc.to_string();
     let mut dataset = FastDataset::new();
     let loader = sophia::jsonld::loader::HttpLoader::default();
@@ -26,8 +25,6 @@ pub fn create_hashed_normalized_doc(
     sophia::c14n::rdfc10::normalize(&dataset, &mut output).map_err(|e| {
         crate::error::Error::Unknown(format!("Error normalizing JSON-LD dataset1: {}", e))
     })?;
-    let mut hasher = sophia::c14n::hash::Sha256::initialize();
-    hasher.update(&output);
 
-    Ok(hasher.finalize())
+    Ok(output)
 }

--- a/core/src/proof/normalization.rs
+++ b/core/src/proof/normalization.rs
@@ -24,9 +24,8 @@ pub fn create_hashed_normalized_doc(
 
     let mut output = Vec::<u8>::new();
     sophia::c14n::rdfc10::normalize(&dataset, &mut output).map_err(|e| {
-        crate::error::Error::Unknown(format!("Error normalizing JSON-LD dataset: {}", e))
+        crate::error::Error::Unknown(format!("Error normalizing JSON-LD dataset1: {}", e))
     })?;
-
     let mut hasher = sophia::c14n::hash::Sha256::initialize();
     hasher.update(&output);
 

--- a/core/src/proof/normalization.rs
+++ b/core/src/proof/normalization.rs
@@ -1,4 +1,20 @@
-pub fn normalize(doc: serde_json::Value) -> impl AsRef<[u8]> {
+use sophia::{api::source::QuadSource, c14n::hash::HashFunction, inmem::dataset::FastDataset};
+
+pub fn normalize(doc: serde_json::Value) -> [u8; 32] {
     let encoded = doc.to_string();
-    encoded.into_bytes()
+    println!("{encoded}");
+    let mut dataset = FastDataset::new();
+    sophia::jsonld::parse_str(&encoded)
+        .add_to_dataset(&mut dataset)
+        .unwrap();
+    println!("dataset {:?}", dataset);
+
+    let mut output = Vec::<u8>::new();
+    sophia::c14n::rdfc10::normalize(&dataset, &mut output).unwrap();
+    println!("output {:?}, length: {:?}", output, output.len());
+
+    let mut hasher = sophia::c14n::hash::Sha256::initialize();
+    hasher.update(&output);
+
+    hasher.finalize()
 }

--- a/registry_resolver/src/lib.rs
+++ b/registry_resolver/src/lib.rs
@@ -182,11 +182,12 @@ mod tests {
     #[tokio::test]
     async fn test_create_did_integration() {
         let did_doc = create_did();
-        let address = "https://reg.sandbox5.knoxnetworks.io";
+        let address = "https://reg.integration.knoxnetworks.io:443";
         let resolver = RegistryResolver::new(address.to_string()).await;
         let document_serialized = create_did_doc(did_doc.clone());
+
         let result = resolver
-            .create(did_doc.to_string(), document_serialized)
+            .create(did_doc.to_string(), document_serialized.clone())
             .await;
         assert!(result.is_ok())
     }

--- a/registry_resolver/src/lib.rs
+++ b/registry_resolver/src/lib.rs
@@ -295,7 +295,6 @@ mod tests {
         };
 
         let res = aw!(resolver.resolve(did));
-        println!("{:?}", res);
         assert_eq!(res.is_ok(), expect_ok);
         match res.err() {
             Some(e) => {

--- a/ssi/Cargo.toml
+++ b/ssi/Cargo.toml
@@ -10,3 +10,4 @@ ssi_core = {path = "../core"}
 registry_resolver = {path = "../registry_resolver"}
 signature = {path = "../signature"}
 ephemeral_resolver = {path = "../ephemeral_resolver"}
+tokio.workspace = true


### PR DESCRIPTION
-  Adds RDFC-1.0 normalization support in place of URDNA2015 (as they are essentially equivalent for our purposes - https://www.w3.org/TR/rdf-canon/#urdna2015) to add complete support for legacy `Ed25519SignatureSystem` support https://www.w3.org/TR/vc-di-eddsa/#the-ed25519signature2020-suite. In future work we'll need to support the new `eddsa-rdfc-2022` and `DataIntegrityProof` approach